### PR TITLE
fix: replace direct gtk dependency with rfd for Linux close dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,6 @@ dependencies = [
  "bytemuck",
  "fontdue",
  "gethostname",
- "gtk",
  "libc",
  "muda",
  "objc2 0.6.3",
@@ -19,6 +18,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "pollster",
  "portable-pty",
+ "rfd",
  "ron",
  "semver",
  "serde",
@@ -585,6 +585,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -2495,6 +2497,33 @@ name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ muda = "0.17"
 gethostname = "1.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-gtk = "0.18"
+rfd = "0.17"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/src/gui/platform/close_dialog.rs
+++ b/src/gui/platform/close_dialog.rs
@@ -109,29 +109,15 @@ fn to_wide(text: &str) -> Vec<u16> {
 
 #[cfg(target_os = "linux")]
 fn confirm_window_close_linux(window: &Window) -> bool {
-    use gtk::prelude::*;
-    use gtk::{ButtonsType, DialogFlags, MessageDialog, MessageType, ResponseType};
-
     let _ = window;
 
-    if !gtk::is_initialized_main_thread() && gtk::init().is_err() {
-        eprintln!("[ferrum] Failed to initialize GTK for close confirmation dialog");
-        return false;
-    }
-
-    let dialog = MessageDialog::new(
-        None::<&gtk::Window>,
-        DialogFlags::MODAL,
-        MessageType::Warning,
-        ButtonsType::OkCancel,
-        "Close Ferrum?",
-    );
-    dialog.set_title("Close Ferrum");
-    dialog.set_secondary_text(Some(
-        "Closing this terminal window will stop all running processes in its tabs.",
-    ));
-    dialog.set_default_response(ResponseType::Cancel);
-    let response = dialog.run();
-    dialog.close();
-    response == ResponseType::Ok
+    rfd::MessageDialog::new()
+        .set_title("Close Ferrum")
+        .set_description(
+            "Closing this terminal window will stop all running processes in its tabs.",
+        )
+        .set_level(rfd::MessageLevel::Warning)
+        .set_buttons(rfd::MessageButtons::OkCancel)
+        .show()
+        == rfd::MessageDialogResult::Ok
 }


### PR DESCRIPTION
## Summary
- Replace direct `gtk` (GTK3, unmaintained) dependency with `rfd` v0.17 for the Linux close confirmation dialog
- Simplifies Linux dialog code from 20 lines to 8 lines
- Note: `muda` still pulls `gtk` transitively for context menus on Linux — this is upstream

## Test plan
- [x] `cargo check` — compiles
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 408 tests pass
- [ ] Manual: close dialog works on Linux