### PR TITLE
fix(ci): use macOS 26 runner for native Liquid Glass tab style

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -82,25 +82,8 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
-      - name: Debug SDK info
-        run: |
-          echo "=== sw_vers ==="
-          sw_vers
-          echo "=== xcrun SDK ==="
-          xcrun --show-sdk-path
-          xcrun --show-sdk-version
-          echo "=== xcode-select ==="
-          xcode-select -p
-          echo "=== rustc deployment target ==="
-          rustc --print=deployment-target
-
       - name: Build release binary
         run: cargo build --release --locked --target "${{ matrix.target }}"
-
-      - name: Debug binary LC_BUILD_VERSION
-        run: |
-          echo "=== otool -l (LC_BUILD_VERSION) ==="
-          otool -l "target/${{ matrix.target }}/release/ferrum" | grep -A5 LC_BUILD_VERSION
 
       - name: Package .app bundle
         run: |


### PR DESCRIPTION
## Summary
- Upgrade ARM CI runner from `macos-14` to `macos-26` (Xcode 26.2, SDK 26.2)
- macOS 26 (Tahoe) checks `LC_BUILD_VERSION.sdk` in the binary to decide whether to apply Liquid Glass styling — binaries built with older SDKs get the pre-Tahoe compact tab appearance
- Intel runner stays on `macos-15-intel` (Intel Macs don't support macOS 26)

## Test plan
- [x] Verify `otool -l` shows `sdk 26.2` in CI-built ARM binary
- [x] Install DMG on macOS 26, confirm tabs match `cargo run` style (separate row below titlebar)
- [x] All CI jobs pass (ARM, Intel, Linux, Windows)