### PR TITLE
fix: send SIGWINCH to surviving pane after closing split

### DIFF
--- a/src/gui/tabs/manage.rs
+++ b/src/gui/tabs/manage.rs
@@ -291,6 +291,9 @@ impl FerrumWindow {
             tab.focused_pane = next_focus;
         }
         self.resize_all_panes();
+        // Closing a pane is a discrete event: the surviving pane expands to fill
+        // the freed space immediately, so SIGWINCH can be sent without debouncing.
+        self.send_sigwinch_to_all_panes();
     }
 
     /// Navigates focus to the nearest pane in the given direction from the currently


### PR DESCRIPTION
## Summary

- `close_focused_pane()` called `resize_all_panes()` but never called `send_sigwinch_to_all_panes()`, leaving the surviving pane's PTY with stale half-width dimensions
- Adds the missing `send_sigwinch_to_all_panes()` call — same pattern already used by `split_pane()`

## Bugs fixed

**Rendering at half width after closing split pane**
Programs such as `claude`, `fzf`, and any CLI tool that queries terminal size via `TIOCGWINSZ` continued to render at the old split width because the shell never received `SIGWINCH` notifying it that the column count doubled.

**Input line disappears when autosuggestions appear**
`reflow_resize` (triggered by the column count change when a split closes) places the terminal cursor at `(row, 0)`. Without a subsequent `SIGWINCH`, the shell's readline keeps tracking its cursor at `(row, col_X)` — the old position in the half-width layout. When autosuggestion escape sequences are emitted relative to `col_X`, they overwrite the reflowed prompt from `col 0`, making the input line appear to vanish.

## Root cause

`split_pane()` already sent SIGWINCH immediately after `resize_all_panes()` with the comment:
> "A pane split is a discrete event, not a drag: dimensions are already final, so SIGWINCH can be sent immediately without debouncing."

The same reasoning applies to closing a pane. The fix mirrors that exact pattern.

## Test plan

- [x] Open a terminal, create a horizontal split, close the split — verify the surviving pane expands to full width and programs render correctly
- [x] After closing a split, type text with autosuggestions active — verify the input line does not disappear
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass