### PR TITLE
feat: improve terminal compatibility (F1-F12, OSC 52, modifyOtherKeys, OSC 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",
+ "base64",
  "bytemuck",
  "gethostname",
  "gtk4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 vte = "0.15"
 unicode-width = "0.2"
 arboard = "3"
+base64 = "0.22"
 ron = "0.12"
 wgpu = { version = "28", optional = true }
 pollster = { version = "0.4", optional = true }

--- a/src/core/grapheme_cell.rs
+++ b/src/core/grapheme_cell.rs
@@ -66,6 +66,8 @@ pub struct GraphemeCell {
     pub reverse: bool,
     pub underline_style: UnderlineStyle,
     pub strikethrough: bool,
+    /// Index into the terminal's hyperlink URL table (0 = no link; n ≥ 1 = URL at index n-1).
+    pub hyperlink_id: u16,
 }
 
 impl GraphemeCell {
@@ -128,6 +130,7 @@ impl Default for GraphemeCell {
             reverse: false,
             underline_style: UnderlineStyle::None,
             strikethrough: false,
+            hyperlink_id: 0,
         }
     }
 }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -670,6 +670,11 @@ impl Perform for Terminal {
                     let id = if let Some(pos) = self.hyperlink_urls.iter().position(|u| u == &url) {
                         (pos + 1) as u16
                     } else {
+                        if self.hyperlink_urls.len() >= 4096 {
+                            // Table full — treat as no hyperlink rather than growing unboundedly.
+                            self.current_hyperlink_id = 0;
+                            return;
+                        }
                         self.hyperlink_urls.push(url);
                         self.hyperlink_urls.len() as u16
                     };
@@ -698,7 +703,8 @@ impl Perform for Terminal {
                         .iter()
                         .nth(1)
                         .and_then(|p| p.first().copied())
-                        .unwrap_or(0) as u8;
+                        .unwrap_or(0)
+                        .min(255) as u8;
                     self.modify_other_keys = level;
                 }
                 return;

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+/// Maximum number of unique hyperlink URLs stored per terminal session.
+const HYPERLINK_URL_TABLE_MAX: usize = 4096;
+
 use base64::Engine as _;
 use crate::config::ThemeChoice;
 use super::{
@@ -672,22 +675,22 @@ impl Perform for Terminal {
                 if uri.is_empty() {
                     self.current_hyperlink_id = 0;
                 } else {
+                    use std::collections::hash_map::Entry;
                     let url = String::from_utf8_lossy(uri).into_owned();
-                    let id = if let Some(&existing_id) = self.hyperlink_url_index.get(&url) {
-                        existing_id
-                    } else {
-                        if self.hyperlink_urls.len() >= 4096 {
-                            // Table full — treat as no hyperlink rather than growing unboundedly.
-                            eprintln!("[ferrum] OSC 8: hyperlink URL table full (4096 entries); ignoring new URL");
-                            self.current_hyperlink_id = 0;
-                            return;
+                    self.current_hyperlink_id = match self.hyperlink_url_index.entry(url) {
+                        Entry::Occupied(e) => *e.get(),
+                        Entry::Vacant(e) => {
+                            if self.hyperlink_urls.len() >= HYPERLINK_URL_TABLE_MAX {
+                                // Table full — treat as no hyperlink rather than growing unboundedly.
+                                eprintln!("[ferrum] OSC 8: hyperlink URL table full ({HYPERLINK_URL_TABLE_MAX} entries); ignoring new URL");
+                                return;
+                            }
+                            let id = (self.hyperlink_urls.len() + 1) as u16;
+                            self.hyperlink_urls.push(e.key().clone());
+                            e.insert(id);
+                            id
                         }
-                        self.hyperlink_urls.push(url.clone());
-                        let id = self.hyperlink_urls.len() as u16;
-                        self.hyperlink_url_index.insert(url, id);
-                        id
                     };
-                    self.current_hyperlink_id = id;
                 }
             }
             _ => {}

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use base64::Engine as _;
 use crate::config::ThemeChoice;
 use super::{
     Color, GraphemeCell, PageCoord, PageList, SecurityConfig,
@@ -96,6 +97,8 @@ pub struct Terminal {
     pub cwd: Option<String>,
     /// Window/icon title set by OSC 0/1/2.
     pub title: Option<String>,
+    /// Decoded clipboard text queued by OSC 52 for the GUI to write to the system clipboard.
+    pub pending_clipboard_write: Option<String>,
 }
 
 impl Terminal {
@@ -152,6 +155,7 @@ impl Terminal {
             parser: Parser::new(),
             cwd: None,
             title: None,
+            pending_clipboard_write: None,
         }
     }
 
@@ -211,6 +215,11 @@ impl Terminal {
     /// Drains all pending PTY response bytes.
     pub fn drain_responses(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.pending_responses)
+    }
+
+    /// Drains a pending clipboard write queued by OSC 52.
+    pub fn drain_clipboard_write(&mut self) -> Option<String> {
+        self.pending_clipboard_write.take()
     }
 
     /// Registers a tracked selection-start pin at the given absolute row/col.
@@ -464,6 +473,7 @@ impl Terminal {
         self.cursor_visible = true;
         self.cursor_style = CursorStyle::default();
         self.pending_responses.clear();
+        self.pending_clipboard_write = None;
         self.bracketed_paste = false;
         if self.security_config.clear_mouse_on_reset {
             self.clear_mouse_tracking(true);
@@ -609,6 +619,22 @@ impl Perform for Terminal {
                 }
                 let uri = String::from_utf8_lossy(params[1]);
                 self.cwd = parse_osc7_uri(&uri);
+            }
+            // OSC 52: clipboard write — params[1] is selection (ignored), params[2] is base64 data
+            b"52" => {
+                if params.len() < 3 {
+                    return;
+                }
+                let payload = params[2];
+                // A payload of "?" is a clipboard read query — ignore it.
+                if payload == b"?" {
+                    return;
+                }
+                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(payload)
+                    && let Ok(text) = String::from_utf8(bytes)
+                {
+                    self.pending_clipboard_write = Some(text);
+                }
             }
             _ => {}
         }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -87,6 +87,8 @@ pub struct Terminal {
     pending_security_events: Vec<SecurityEventKind>,
     pub cursor_style: CursorStyle,
     pub resize_at: Option<Instant>,
+    /// modifyOtherKeys level set by `ESC [ > 4 ; <n> m` (0 = off, 1 = level 1, 2 = level 2).
+    pub modify_other_keys: u8,
 
     // ── Selection pins ───────────────────────────────────────────────────────
     pub selection_start_pin: Option<TrackedPin>,
@@ -150,6 +152,7 @@ impl Terminal {
             pending_security_events: Vec::new(),
             cursor_style: CursorStyle::default(),
             resize_at: None,
+            modify_other_keys: 0,
             selection_start_pin: None,
             selection_end_pin: None,
             parser: Parser::new(),
@@ -475,6 +478,7 @@ impl Terminal {
         self.pending_responses.clear();
         self.pending_clipboard_write = None;
         self.bracketed_paste = false;
+        self.modify_other_keys = 0;
         if self.security_config.clear_mouse_on_reset {
             self.clear_mouse_tracking(true);
         }
@@ -651,6 +655,18 @@ impl Perform for Terminal {
             return;
         }
         if action == 'm' {
+            if intermediates == b">" {
+                // modifyOtherKeys: ESC [ > 4 ; <level> m
+                if self.param(params, 0) == 4 {
+                    let level = params
+                        .iter()
+                        .nth(1)
+                        .and_then(|p| p.first().copied())
+                        .unwrap_or(0) as u8;
+                    self.modify_other_keys = level;
+                }
+                return;
+            }
             self.handle_sgr(params);
             return;
         }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -101,6 +101,12 @@ pub struct Terminal {
     pub title: Option<String>,
     /// Decoded clipboard text queued by OSC 52 for the GUI to write to the system clipboard.
     pub pending_clipboard_write: Option<String>,
+
+    // ── OSC 8 hyperlinks ─────────────────────────────────────────────────────
+    /// URL table: index 0 corresponds to hyperlink_id 1.
+    hyperlink_urls: Vec<String>,
+    /// Currently active hyperlink id (0 = none).
+    current_hyperlink_id: u16,
 }
 
 impl Terminal {
@@ -159,6 +165,8 @@ impl Terminal {
             cwd: None,
             title: None,
             pending_clipboard_write: None,
+            hyperlink_urls: Vec::new(),
+            current_hyperlink_id: 0,
         }
     }
 
@@ -223,6 +231,14 @@ impl Terminal {
     /// Drains a pending clipboard write queued by OSC 52.
     pub fn drain_clipboard_write(&mut self) -> Option<String> {
         self.pending_clipboard_write.take()
+    }
+
+    /// Returns the URL associated with the given hyperlink id, or `None` if the id is 0 or out of range.
+    pub fn hyperlink_url(&self, id: u16) -> Option<&str> {
+        if id == 0 {
+            return None;
+        }
+        self.hyperlink_urls.get((id - 1) as usize).map(String::as_str)
     }
 
     /// Registers a tracked selection-start pin at the given absolute row/col.
@@ -483,6 +499,8 @@ impl Terminal {
             self.clear_mouse_tracking(true);
         }
         self.cwd = None;
+        self.hyperlink_urls.clear();
+        self.current_hyperlink_id = 0;
         self.reset_attributes();
         self.parser = Parser::new();
         self.reset_screen_buffer();
@@ -559,6 +577,7 @@ impl Perform for Terminal {
         gc.reverse = self.current_reverse;
         gc.underline_style = self.current_underline_style;
         gc.strikethrough = self.current_strikethrough;
+        gc.hyperlink_id = self.current_hyperlink_id;
         self.screen.viewport_set(cr, cc, gc);
 
         // Reserve the trailing cell for wide glyphs.
@@ -638,6 +657,23 @@ impl Perform for Terminal {
                     && let Ok(text) = String::from_utf8(bytes)
                 {
                     self.pending_clipboard_write = Some(text);
+                }
+            }
+            // OSC 8: hyperlinks — OSC 8 ; params ; uri ST
+            b"8" => {
+                let uri = params.get(2).copied().unwrap_or(b"");
+                if uri.is_empty() {
+                    self.current_hyperlink_id = 0;
+                } else {
+                    let url = String::from_utf8_lossy(uri).into_owned();
+                    // Reuse existing entry to avoid unbounded URL table growth.
+                    let id = if let Some(pos) = self.hyperlink_urls.iter().position(|u| u == &url) {
+                        (pos + 1) as u16
+                    } else {
+                        self.hyperlink_urls.push(url);
+                        self.hyperlink_urls.len() as u16
+                    };
+                    self.current_hyperlink_id = id;
                 }
             }
             _ => {}

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
-/// Maximum number of unique hyperlink URLs stored per terminal session.
-const HYPERLINK_URL_TABLE_MAX: usize = 4096;
-
 use base64::Engine as _;
 use crate::config::ThemeChoice;
 use super::{
@@ -12,6 +9,9 @@ use super::{
 };
 use unicode_width::UnicodeWidthChar;
 use vte::{Params, Parser, Perform};
+
+/// Maximum number of unique hyperlink URLs stored per terminal session.
+const HYPERLINK_URL_TABLE_MAX: usize = 4096;
 
 mod alt_screen;
 mod grid_ops;

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Instant;
 
 use base64::Engine as _;
@@ -105,6 +106,8 @@ pub struct Terminal {
     // ── OSC 8 hyperlinks ─────────────────────────────────────────────────────
     /// URL table: index 0 corresponds to hyperlink_id 1.
     hyperlink_urls: Vec<String>,
+    /// Companion index for O(1) URL deduplication (url → hyperlink_id).
+    hyperlink_url_index: HashMap<String, u16>,
     /// Currently active hyperlink id (0 = none).
     current_hyperlink_id: u16,
 }
@@ -166,6 +169,7 @@ impl Terminal {
             title: None,
             pending_clipboard_write: None,
             hyperlink_urls: Vec::new(),
+            hyperlink_url_index: HashMap::new(),
             current_hyperlink_id: 0,
         }
     }
@@ -500,6 +504,7 @@ impl Terminal {
         }
         self.cwd = None;
         self.hyperlink_urls.clear();
+        self.hyperlink_url_index.clear();
         self.current_hyperlink_id = 0;
         self.reset_attributes();
         self.parser = Parser::new();
@@ -660,23 +665,26 @@ impl Perform for Terminal {
                 }
             }
             // OSC 8: hyperlinks — OSC 8 ; params ; uri ST
+            // params[1] may contain link attributes (e.g. `id=foo`) per spec; we ignore them
+            // since most tools do not use them and URL-based deduplication is sufficient.
             b"8" => {
                 let uri = params.get(2).copied().unwrap_or(b"");
                 if uri.is_empty() {
                     self.current_hyperlink_id = 0;
                 } else {
                     let url = String::from_utf8_lossy(uri).into_owned();
-                    // Reuse existing entry to avoid unbounded URL table growth.
-                    let id = if let Some(pos) = self.hyperlink_urls.iter().position(|u| u == &url) {
-                        (pos + 1) as u16
+                    let id = if let Some(&existing_id) = self.hyperlink_url_index.get(&url) {
+                        existing_id
                     } else {
                         if self.hyperlink_urls.len() >= 4096 {
                             // Table full — treat as no hyperlink rather than growing unboundedly.
                             self.current_hyperlink_id = 0;
                             return;
                         }
-                        self.hyperlink_urls.push(url);
-                        self.hyperlink_urls.len() as u16
+                        self.hyperlink_urls.push(url.clone());
+                        let id = self.hyperlink_urls.len() as u16;
+                        self.hyperlink_url_index.insert(url, id);
+                        id
                     };
                     self.current_hyperlink_id = id;
                 }

--- a/src/core/terminal.rs
+++ b/src/core/terminal.rs
@@ -678,6 +678,7 @@ impl Perform for Terminal {
                     } else {
                         if self.hyperlink_urls.len() >= 4096 {
                             // Table full — treat as no hyperlink rather than growing unboundedly.
+                            eprintln!("[ferrum] OSC 8: hyperlink URL table full (4096 entries); ignoring new URL");
                             self.current_hyperlink_id = 0;
                             return;
                         }
@@ -712,7 +713,7 @@ impl Perform for Terminal {
                         .nth(1)
                         .and_then(|p| p.first().copied())
                         .unwrap_or(0)
-                        .min(255) as u8;
+                        .min(2) as u8;
                     self.modify_other_keys = level;
                 }
                 return;

--- a/src/gui/events/keyboard/forward.rs
+++ b/src/gui/events/keyboard/forward.rs
@@ -1,4 +1,4 @@
-use crate::gui::input::key_to_bytes;
+use crate::gui::input::key_to_bytes_ex;
 use crate::gui::*;
 
 impl FerrumWindow {
@@ -17,8 +17,11 @@ impl FerrumWindow {
         }
         self.keyboard_selection_anchor = None;
 
-        let decckm = self.active_leaf_ref().is_some_and(|l| l.terminal.decckm);
-        let Some(bytes) = key_to_bytes(key, self.modifiers, decckm) else {
+        let (decckm, modify_other_keys) = self
+            .active_leaf_ref()
+            .map(|l| (l.terminal.decckm, l.terminal.modify_other_keys))
+            .unwrap_or((false, 0));
+        let Some(bytes) = key_to_bytes_ex(key, self.modifiers, decckm, modify_other_keys) else {
             return;
         };
         if let Some(leaf) = self.active_leaf_mut() {

--- a/src/gui/events/mouse/terminal_click.rs
+++ b/src/gui/events/mouse/terminal_click.rs
@@ -70,14 +70,11 @@ impl FerrumWindow {
 
                 if self.modifiers.control_key() && !self.is_mouse_reporting()
                     && let Some(leaf) = self.tabs[idx].focused_leaf()
-                {
-                    let cell = &leaf.terminal.screen.viewport_row(row).cells[col];
-                    let hyperlink_id = cell.hyperlink_id;
-                    if let Some(url) = leaf.terminal.hyperlink_url(hyperlink_id) {
-                        open_url(url);
-                        self.is_selecting = false;
-                        return;
-                    }
+                    && let Some(cell) = leaf.terminal.screen.viewport_row(row).cells.get(col)
+                    && let Some(url) = leaf.terminal.hyperlink_url(cell.hyperlink_id) {
+                    open_url(url);
+                    self.is_selecting = false;
+                    return;
                 }
 
                 if self.modifiers.shift_key() {

--- a/src/gui/events/mouse/terminal_click.rs
+++ b/src/gui/events/mouse/terminal_click.rs
@@ -1,5 +1,6 @@
 use crate::core::PageCoord;
 use crate::gui::*;
+use super::update_banner::open_url;
 
 impl FerrumWindow {
     fn update_terminal_click_streak(&mut self, pos: Position) -> u8 {
@@ -66,6 +67,18 @@ impl FerrumWindow {
             ElementState::Pressed => {
                 self.is_selecting = true;
                 self.keyboard_selection_anchor = None;
+
+                if self.modifiers.control_key() && !self.is_mouse_reporting()
+                    && let Some(leaf) = self.tabs[idx].focused_leaf()
+                {
+                    let cell = &leaf.terminal.screen.viewport_row(row).cells[col];
+                    let hyperlink_id = cell.hyperlink_id;
+                    if let Some(url) = leaf.terminal.hyperlink_url(hyperlink_id) {
+                        open_url(url);
+                        self.is_selecting = false;
+                        return;
+                    }
+                }
 
                 if self.modifiers.shift_key() {
                     self.click_streak = 0;

--- a/src/gui/events/mouse/update_banner.rs
+++ b/src/gui/events/mouse/update_banner.rs
@@ -108,7 +108,7 @@ impl FerrumWindow {
 }
 
 /// Opens a URL in the system default browser.
-fn open_url(url: &str) {
+pub(super) fn open_url(url: &str) {
     #[cfg(target_os = "macos")]
     std::process::Command::new("open").arg(url).spawn().ok();
     #[cfg(target_os = "windows")]

--- a/src/gui/events/pty.rs
+++ b/src/gui/events/pty.rs
@@ -14,6 +14,12 @@ impl FerrumWindow {
                     && let Some(leaf) = tab.pane_tree.find_leaf_mut(*pane_id)
                 {
                     leaf.process_and_flush(bytes);
+                    if let Some(text) = leaf.terminal.drain_clipboard_write()
+                        && let Some(ref mut clipboard) = self.clipboard
+                        && let Err(e) = clipboard.set_text(&text)
+                    {
+                        eprintln!("OSC 52: failed to write to clipboard: {e}");
+                    }
                 }
             }
             PtyEvent::Exited { tab_id, pane_id } => {

--- a/src/gui/input.rs
+++ b/src/gui/input.rs
@@ -125,8 +125,13 @@ pub(super) fn encode_mouse_event(
     }
 }
 
-/// Converts logical key input into PTY byte sequences.
-pub(super) fn key_to_bytes(key: &Key, modifiers: ModifiersState, decckm: bool) -> Option<Vec<u8>> {
+/// Converts logical key input into PTY byte sequences, respecting modifyOtherKeys level.
+pub(super) fn key_to_bytes_ex(
+    key: &Key,
+    modifiers: ModifiersState,
+    decckm: bool,
+    modify_other_keys: u8,
+) -> Option<Vec<u8>> {
     match key {
         Key::Character(c) => {
             let ch = c.chars().next()?;
@@ -152,7 +157,17 @@ pub(super) fn key_to_bytes(key: &Key, modifiers: ModifiersState, decckm: bool) -
             let modifier_param = csi_modifier_param(modifiers);
 
             match named {
-                NamedKey::Enter => Some(with_alt_prefix(vec![b'\r'], modifiers)),
+                NamedKey::Enter => {
+                    if modify_other_keys >= 2
+                        && modifiers.shift_key()
+                        && !modifiers.control_key()
+                        && !modifiers.alt_key()
+                    {
+                        Some(b"\x1b[27;2;13~".to_vec())
+                    } else {
+                        Some(with_alt_prefix(vec![b'\r'], modifiers))
+                    }
+                }
                 NamedKey::Backspace => {
                     if is_word_delete_combo(modifiers) {
                         Some(vec![0x17]) // Ctrl+W — backward-kill-word
@@ -245,6 +260,14 @@ pub(super) fn key_to_bytes(key: &Key, modifiers: ModifiersState, decckm: bool) -
         }
         _ => None,
     }
+}
+
+/// Converts logical key input into PTY byte sequences (modifyOtherKeys level 0).
+///
+/// Used only in tests; production callers use `key_to_bytes_ex` directly.
+#[cfg(test)]
+pub(super) fn key_to_bytes(key: &Key, modifiers: ModifiersState, decckm: bool) -> Option<Vec<u8>> {
+    key_to_bytes_ex(key, modifiers, decckm, 0)
 }
 
 #[cfg(test)]

--- a/src/gui/input.rs
+++ b/src/gui/input.rs
@@ -214,6 +214,32 @@ pub(super) fn key_to_bytes(key: &Key, modifiers: ModifiersState, decckm: bool) -
                 }
                 NamedKey::PageUp => Some(csi_tilde(5, modifier_param)),
                 NamedKey::PageDown => Some(csi_tilde(6, modifier_param)),
+                // F1–F4: SS3 sequences without modifier, CSI 1;{mod}{letter} with modifier
+                NamedKey::F1 => Some(match modifier_param {
+                    Some(param) => csi_with_modifier('P', param),
+                    None => b"\x1bOP".to_vec(),
+                }),
+                NamedKey::F2 => Some(match modifier_param {
+                    Some(param) => csi_with_modifier('Q', param),
+                    None => b"\x1bOQ".to_vec(),
+                }),
+                NamedKey::F3 => Some(match modifier_param {
+                    Some(param) => csi_with_modifier('R', param),
+                    None => b"\x1bOR".to_vec(),
+                }),
+                NamedKey::F4 => Some(match modifier_param {
+                    Some(param) => csi_with_modifier('S', param),
+                    None => b"\x1bOS".to_vec(),
+                }),
+                // F5–F12: CSI tilde sequences (16 and 22 are historically skipped)
+                NamedKey::F5 => Some(csi_tilde(15, modifier_param)),
+                NamedKey::F6 => Some(csi_tilde(17, modifier_param)),
+                NamedKey::F7 => Some(csi_tilde(18, modifier_param)),
+                NamedKey::F8 => Some(csi_tilde(19, modifier_param)),
+                NamedKey::F9 => Some(csi_tilde(20, modifier_param)),
+                NamedKey::F10 => Some(csi_tilde(21, modifier_param)),
+                NamedKey::F11 => Some(csi_tilde(23, modifier_param)),
+                NamedKey::F12 => Some(csi_tilde(24, modifier_param)),
                 _ => None,
             }
         }

--- a/src/gui/input.rs
+++ b/src/gui/input.rs
@@ -88,15 +88,11 @@ fn encode_arrow_key(final_byte: char, decckm: bool, modifier_param: Option<u8>) 
     }
 }
 
-fn encode_home_end_key(final_byte: char, decckm: bool, modifier_param: Option<u8>) -> Vec<u8> {
-    if let Some(param) = modifier_param {
-        return csi_with_modifier(final_byte, param);
-    }
-
-    if decckm {
-        format!("\x1bO{}", final_byte).into_bytes()
-    } else {
-        format!("\x1b[{}", final_byte).into_bytes()
+/// Encodes an SS3 function key (F1–F4): `ESC O {letter}` unmodified, or `ESC [ 1 ; {mod} {letter}` with a modifier.
+fn encode_ss3_key(final_byte: char, modifier_param: Option<u8>) -> Vec<u8> {
+    match modifier_param {
+        Some(param) => csi_with_modifier(final_byte, param),
+        None => vec![0x1b, b'O', final_byte as u8],
     }
 }
 
@@ -217,8 +213,8 @@ pub(super) fn key_to_bytes_ex(
                         Some(encode_arrow_key('D', decckm, modifier_param))
                     }
                 }
-                NamedKey::Home => Some(encode_home_end_key('H', decckm, modifier_param)),
-                NamedKey::End => Some(encode_home_end_key('F', decckm, modifier_param)),
+                NamedKey::Home => Some(encode_arrow_key('H', decckm, modifier_param)),
+                NamedKey::End => Some(encode_arrow_key('F', decckm, modifier_param)),
                 NamedKey::Insert => Some(csi_tilde(2, modifier_param)),
                 NamedKey::Delete => {
                     if is_word_delete_combo(modifiers) {
@@ -230,22 +226,10 @@ pub(super) fn key_to_bytes_ex(
                 NamedKey::PageUp => Some(csi_tilde(5, modifier_param)),
                 NamedKey::PageDown => Some(csi_tilde(6, modifier_param)),
                 // F1–F4: SS3 sequences without modifier, CSI 1;{mod}{letter} with modifier
-                NamedKey::F1 => Some(match modifier_param {
-                    Some(param) => csi_with_modifier('P', param),
-                    None => b"\x1bOP".to_vec(),
-                }),
-                NamedKey::F2 => Some(match modifier_param {
-                    Some(param) => csi_with_modifier('Q', param),
-                    None => b"\x1bOQ".to_vec(),
-                }),
-                NamedKey::F3 => Some(match modifier_param {
-                    Some(param) => csi_with_modifier('R', param),
-                    None => b"\x1bOR".to_vec(),
-                }),
-                NamedKey::F4 => Some(match modifier_param {
-                    Some(param) => csi_with_modifier('S', param),
-                    None => b"\x1bOS".to_vec(),
-                }),
+                NamedKey::F1 => Some(encode_ss3_key('P', modifier_param)),
+                NamedKey::F2 => Some(encode_ss3_key('Q', modifier_param)),
+                NamedKey::F3 => Some(encode_ss3_key('R', modifier_param)),
+                NamedKey::F4 => Some(encode_ss3_key('S', modifier_param)),
                 // F5–F12: CSI tilde sequences (16 and 22 are historically skipped)
                 NamedKey::F5 => Some(csi_tilde(15, modifier_param)),
                 NamedKey::F6 => Some(csi_tilde(17, modifier_param)),

--- a/tests/unit/core_terminal.rs
+++ b/tests/unit/core_terminal.rs
@@ -658,3 +658,37 @@ fn modify_other_keys_reset_by_csi_without_param() {
     term.process(b"\x1b[>4m");
     assert_eq!(term.modify_other_keys, 0);
 }
+
+#[test]
+fn modify_other_keys_clamps_level_above_2() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b[>4;9m");
+    assert_eq!(term.modify_other_keys, 2, "level above 2 should be clamped to 2");
+}
+
+// ── full_reset clears OSC 8 and modifyOtherKeys state ──
+
+#[test]
+fn full_reset_clears_hyperlink_state() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b]8;;https://example.com\x07hi\x1b]8;;\x07");
+    let id = term.screen.viewport_row(0).cells[0].hyperlink_id;
+    assert!(id != 0, "hyperlink should be set before reset");
+
+    term.full_reset();
+
+    assert_eq!(term.hyperlink_url(id), None, "URL table should be cleared after full_reset");
+    let row = term.screen.viewport_row(0);
+    assert_eq!(row.cells[0].hyperlink_id, 0, "cells should have no hyperlink after full_reset");
+}
+
+#[test]
+fn full_reset_clears_modify_other_keys() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b[>4;2m");
+    assert_eq!(term.modify_other_keys, 2);
+
+    term.full_reset();
+
+    assert_eq!(term.modify_other_keys, 0, "modifyOtherKeys should be 0 after full_reset");
+}

--- a/tests/unit/core_terminal.rs
+++ b/tests/unit/core_terminal.rs
@@ -601,3 +601,25 @@ fn osc52_invalid_base64_is_ignored() {
     term.process(b"\x1b]52;c;!!!invalid!!!\x07");
     assert!(term.pending_clipboard_write.is_none());
 }
+
+// ── modifyOtherKeys ──
+
+#[test]
+fn modify_other_keys_level_set_by_csi_sequence() {
+    let mut term = Terminal::new(24, 80);
+    assert_eq!(term.modify_other_keys, 0);
+    term.process(b"\x1b[>4;2m");
+    assert_eq!(term.modify_other_keys, 2);
+    term.process(b"\x1b[>4;1m");
+    assert_eq!(term.modify_other_keys, 1);
+    term.process(b"\x1b[>4;0m");
+    assert_eq!(term.modify_other_keys, 0);
+}
+
+#[test]
+fn modify_other_keys_reset_by_csi_without_param() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b[>4;2m");
+    term.process(b"\x1b[>4m");
+    assert_eq!(term.modify_other_keys, 0);
+}

--- a/tests/unit/core_terminal.rs
+++ b/tests/unit/core_terminal.rs
@@ -602,6 +602,41 @@ fn osc52_invalid_base64_is_ignored() {
     assert!(term.pending_clipboard_write.is_none());
 }
 
+// ── OSC 8 hyperlinks ──
+
+#[test]
+fn osc8_sets_hyperlink_on_subsequent_cells() {
+    let mut term = Terminal::new(24, 80);
+    // Start hyperlink, write "hi", end hyperlink
+    term.process(b"\x1b]8;;https://example.com\x07hi\x1b]8;;\x07");
+    let row = term.screen.viewport_row(0);
+    assert!(row.cells[0].hyperlink_id != 0, "first cell should have hyperlink");
+    assert!(row.cells[1].hyperlink_id != 0, "second cell should have hyperlink");
+    assert_eq!(row.cells[2].hyperlink_id, 0, "cell after end should have no hyperlink");
+    assert_eq!(
+        term.hyperlink_url(row.cells[0].hyperlink_id),
+        Some("https://example.com")
+    );
+}
+
+#[test]
+fn osc8_empty_uri_ends_hyperlink() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b]8;;https://x.com\x07a\x1b]8;;\x07b");
+    let row = term.screen.viewport_row(0);
+    assert!(row.cells[0].hyperlink_id != 0);
+    assert_eq!(row.cells[1].hyperlink_id, 0);
+}
+
+#[test]
+fn osc8_same_url_reuses_id() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b]8;;https://a.com\x07x\x1b]8;;\x07");
+    term.process(b"\x1b]8;;https://a.com\x07y\x1b]8;;\x07");
+    let row = term.screen.viewport_row(0);
+    assert_eq!(row.cells[0].hyperlink_id, row.cells[1].hyperlink_id, "same URL should reuse same ID");
+}
+
 // ── modifyOtherKeys ──
 
 #[test]

--- a/tests/unit/core_terminal.rs
+++ b/tests/unit/core_terminal.rs
@@ -577,3 +577,27 @@ fn reflow_intensive_varying_sizes_preserves_content() {
     assert_eq!(get_char(&term, 8, 0), 'I', "row I lost after varying reflow");
     assert_eq!(get_char(&term, 9, 0), 'J', "row J lost after varying reflow");
 }
+
+// ── OSC 52 clipboard write ──
+
+#[test]
+fn osc52_writes_decoded_text_to_pending_clipboard() {
+    let mut term = Terminal::new(24, 80);
+    // "hello" in base64 is "aGVsbG8="
+    term.process(b"\x1b]52;c;aGVsbG8=\x07");
+    assert_eq!(term.pending_clipboard_write.as_deref(), Some("hello"));
+}
+
+#[test]
+fn osc52_query_is_ignored() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b]52;c;?\x07");
+    assert!(term.pending_clipboard_write.is_none());
+}
+
+#[test]
+fn osc52_invalid_base64_is_ignored() {
+    let mut term = Terminal::new(24, 80);
+    term.process(b"\x1b]52;c;!!!invalid!!!\x07");
+    assert!(term.pending_clipboard_write.is_none());
+}

--- a/tests/unit/gui_input.rs
+++ b/tests/unit/gui_input.rs
@@ -165,3 +165,53 @@ fn legacy_mouse_encoding_clamps_large_coordinates() {
     let bytes = encode_mouse_event(0, 300, 500, true, false);
     assert_eq!(bytes, vec![0x1b, b'[', b'M', 32, 255, 255]);
 }
+
+#[test]
+fn f1_through_f4_use_ss3_sequences() {
+    use winit::keyboard::NamedKey;
+    let cases = [
+        (NamedKey::F1, b"\x1bOP".as_ref()),
+        (NamedKey::F2, b"\x1bOQ".as_ref()),
+        (NamedKey::F3, b"\x1bOR".as_ref()),
+        (NamedKey::F4, b"\x1bOS".as_ref()),
+    ];
+    for (key, expected) in cases {
+        let bytes = key_to_bytes(&Key::Named(key), ModifiersState::empty(), false)
+            .expect("F key should be encoded");
+        assert_eq!(bytes, expected, "{key:?} should produce SS3 sequence");
+    }
+}
+
+#[test]
+fn f5_through_f12_use_csi_tilde_sequences() {
+    use winit::keyboard::NamedKey;
+    let cases = [
+        (NamedKey::F5,  b"\x1b[15~".as_ref()),
+        (NamedKey::F6,  b"\x1b[17~".as_ref()),
+        (NamedKey::F7,  b"\x1b[18~".as_ref()),
+        (NamedKey::F8,  b"\x1b[19~".as_ref()),
+        (NamedKey::F9,  b"\x1b[20~".as_ref()),
+        (NamedKey::F10, b"\x1b[21~".as_ref()),
+        (NamedKey::F11, b"\x1b[23~".as_ref()),
+        (NamedKey::F12, b"\x1b[24~".as_ref()),
+    ];
+    for (key, expected) in cases {
+        let bytes = key_to_bytes(&Key::Named(key), ModifiersState::empty(), false)
+            .expect("F key should be encoded");
+        assert_eq!(bytes, expected, "{key:?} should produce CSI tilde sequence");
+    }
+}
+
+#[test]
+fn f1_with_shift_uses_modifier_encoding() {
+    let bytes = key_to_bytes(&Key::Named(NamedKey::F1), mods(false, true, false), false)
+        .expect("Shift+F1 should be encoded");
+    assert_eq!(bytes, b"\x1b[1;2P");
+}
+
+#[test]
+fn f5_with_ctrl_uses_modifier_encoding() {
+    let bytes = key_to_bytes(&Key::Named(NamedKey::F5), mods(true, false, false), false)
+        .expect("Ctrl+F5 should be encoded");
+    assert_eq!(bytes, b"\x1b[15;5~");
+}

--- a/tests/unit/gui_input.rs
+++ b/tests/unit/gui_input.rs
@@ -215,3 +215,39 @@ fn f5_with_ctrl_uses_modifier_encoding() {
         .expect("Ctrl+F5 should be encoded");
     assert_eq!(bytes, b"\x1b[15;5~");
 }
+
+#[test]
+fn shift_enter_with_modify_other_keys_level2_produces_csi_27() {
+    let bytes = key_to_bytes_ex(
+        &Key::Named(NamedKey::Enter),
+        mods(false, true, false),
+        false,
+        2,
+    )
+    .expect("Shift+Enter with modifyOtherKeys=2 should be encoded");
+    assert_eq!(bytes, b"\x1b[27;2;13~");
+}
+
+#[test]
+fn plain_enter_with_modify_other_keys_level2_still_produces_cr() {
+    let bytes = key_to_bytes_ex(
+        &Key::Named(NamedKey::Enter),
+        ModifiersState::empty(),
+        false,
+        2,
+    )
+    .expect("Enter should be encoded");
+    assert_eq!(bytes, vec![b'\r']);
+}
+
+#[test]
+fn shift_enter_without_modify_other_keys_still_produces_cr() {
+    let bytes = key_to_bytes_ex(
+        &Key::Named(NamedKey::Enter),
+        mods(false, true, false),
+        false,
+        0,
+    )
+    .expect("Shift+Enter without mode should be encoded");
+    assert_eq!(bytes, vec![b'\r']);
+}


### PR DESCRIPTION
## Summary

- **F1–F12 function keys**: encode all 12 function keys with correct VT220/xterm sequences (SS3 for F1–F4 via \`encode_ss3_key\`, CSI tilde for F5–F12, modifier support for all)
- **OSC 52 clipboard write**: decode base64 payload and write to system clipboard, enabling neovim + SSH and tmux clipboard passthrough
- **modifyOtherKeys (Shift+Enter)**: implement XTerm \`CSI > 4 ; n m\` mode; at level 2, Shift+Enter produces \`\x1b[27;2;13~\` instead of \`\r\`, enabling Claude Code and modern editor plugins
- **OSC 8 hyperlinks + Ctrl+Click**: track per-cell hyperlink URLs via a capped URL table (4096 entries, O(1) lookup via HashMap); Ctrl+Click opens URL in default browser

## Test Plan

- [ ] \`cargo clippy\` — zero warnings
- [ ] \`cargo test\` — 326 tests pass
- [ ] Open nano, verify F1 shows help and F2 exits
- [ ] Run \`printf '\e]52;c;%s\a' "$(echo -n 'hello' | base64)"\`, verify "hello" lands in clipboard
- [ ] Run Claude Code, verify Shift+Enter inserts newline without submitting (requires app to set modifyOtherKeys level 2)
- [ ] Run \`printf '\e]8;;https://example.com\ahello\e]8;;\a\n'\`, Ctrl+Click on "hello" to open URL